### PR TITLE
fix: use correct config values for nuxt v3 MDC

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -128,10 +128,14 @@ export default defineNuxtConfig({
 
   // Content config (https://content.nuxtjs.org/api/configuration)
   content: {
-      highlight: {
+     build: {
+      markdown: {
+        highlight: {
           theme: 'github-dark-dimmed',
-          preload: ['js', 'java', 'yaml', 'toml', 'xml', 'groovy']
+          langs: ['js', 'java', 'yaml','toml', 'xml', 'groovy']
+        }
       }
+    }
   },
 
   // Internationalization


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0f9747a3-1899-4907-9e55-03bbb76b863b)
As you can see syntax highlighting for java isnt working because its not loaded in the defaults and the nuxt config was using the v2 values.